### PR TITLE
Avoid matplotlib error by plotting in chunks

### DIFF
--- a/mplot/plot.py
+++ b/mplot/plot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Copyright (c) 2017 Muxr, http://www.eevblog.com/forum/profile/?u=105823
 
@@ -31,6 +33,16 @@ import matplotlib.ticker as plticker
 from matplotlib.ticker import FormatStrFormatter
 import argparse
 import sys
+
+# By default, matplotlib will try to plot all of the data points in
+# one pass.  If you are plotting more than a few days worth of data
+# (e.g. ~1 million data points), you'll likely hit this error:
+#
+#   "OverflowError: Allocated too many blocks"
+#
+# To avoid this, we instruct matplotlib to break up the plot into
+# chunks.  Thanks to https://stackoverflow.com/a/23361090
+matplotlib.rcParams['agg.path.chunksize'] = 100000
 
 COLORS = ["#6e3c82", "#3498db", "#95a5a6", "#e74c3c", "#34495e", "#2ecc71"]
 

--- a/mplot/plot.py
+++ b/mplot/plot.py
@@ -42,6 +42,7 @@ import sys
 #
 # To avoid this, we instruct matplotlib to break up the plot into
 # chunks.  Thanks to https://stackoverflow.com/a/23361090
+import matplotlib
 matplotlib.rcParams['agg.path.chunksize'] = 100000
 
 COLORS = ["#6e3c82", "#3498db", "#95a5a6", "#e74c3c", "#34495e", "#2ecc71"]
@@ -80,7 +81,16 @@ def plot(options):
     sns.set(style="darkgrid")
     sns.set_palette(COLORS)
 
-    df = pd.read_csv(options.infile, delimiter=';')
+    df = pd.read_csv(options.infile, delimiter=',')
+
+    # Apply a rolling average filter if requested via cmdline options.
+    if options.avg_window is not None:
+        window_len = options.avg_window
+        avg_df = df.rolling(window=window_len).mean()
+        # Until the window fills up, the output will be a bunch of NaN values,
+        # which we remove here:
+        avg_df = avg_df[window_len-1:]
+        df = avg_df
 
     plt.locator_params(axis='y', nticks=20)
 
@@ -170,6 +180,12 @@ def main():
                         action='store',
                         default="7",
                         help='Number of least significant digits in the Y labels')
+    parser.add_argument('-a',
+                        '--rolling-average-window',
+                        dest='avg_window',
+                        type=int,
+                        action='store',
+                        help='Apply a rolling-average with a window of N data points')
     options = parser.parse_args()
 
     if options.infile is None:


### PR DESCRIPTION
This PR configures matplotlib to plot in chunks, rather than considering the entire dataset at once.

This avoids the "OverflowError: Allocated too many blocks" described here: https://stackoverflow.com/questions/20330475/matplotlib-overflowerror-allocated-too-many-blocks/23361090#23361090